### PR TITLE
Fix compatibility with HA Core 2025.12+ and API null value handling

### DIFF
--- a/custom_components/drivvo/__init__.py
+++ b/custom_components/drivvo/__init__.py
@@ -262,15 +262,16 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
             refuelling_value_total = 0
             refuelling_volume_total = 0
             for refuelling in api_data_refuellings:
-                refuelling_value_total += refuelling["valor_total"]
+                refuelling_value_total += refuelling.get("valor_total") or 0
 
                 if refuelling["volume"] != 0:
-                    refuelling_volume_total += refuelling["volume"]
+                    refuelling_volume_total += refuelling.get("volume") or 0
                 else:
-                    refuelling_volume_total += (
-                        refuelling["valor_total"] / refuelling["preco"]
-                    )
-
+                    volume_calc = 0
+                    if refuelling.get("preco") and refuelling.get("preco") != 0:
+                        volume_calc = refuelling["valor_total"] / refuelling["preco"]
+                    refuelling_volume_total += volume_calc
+    
             refuelling_distance = 0
             refuellings_odometers = [
                 {
@@ -318,11 +319,14 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
                             odometer_old = odometer["odometro"]
                             break
 
-                        if odometer["volume"] != 0:
-                            volume += odometer["volume"]
+                        if odometer.get("volume") and odometer["volume"] != 0:
+                            volume += odometer.get("volume") or 0
                         else:
-                            volume += odometer["valor_total"] / odometer["preco"]
-
+                            volume_calc = 0
+                            if odometer.get("preco") and odometer["preco"] != 0:
+                                volume_calc = odometer["valor_total"] / odometer["preco"]
+                            volume += volume_calc
+                
                 if volume > 0 and odometer_old is not None:
                     refuelling_last_average = (
                         refuellings_odometers[0]["odometro"] - odometer_old

--- a/custom_components/drivvo/config_flow.py
+++ b/custom_components/drivvo/config_flow.py
@@ -37,10 +37,9 @@ DATA_SCHEMA: vol.Schema = vol.Schema(
 class DrivvoOptionsFlowHandler(config_entries.OptionsFlow):
     """Config flow options for Drivvo."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize Drivvo options flow."""
-        self.config_entry: config_entries.ConfigEntry = config_entry
-
+    
     async def async_step_init(self, user_input: dict[str, Any]) -> FlowResult:
         """Manage the options."""
 
@@ -317,4 +316,4 @@ class DrivvoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Options callback for Drivvo."""
-        return DrivvoOptionsFlowHandler(config_entry)
+        return DrivvoOptionsFlowHandler()

--- a/custom_components/drivvo/manifest.json
+++ b/custom_components/drivvo/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-drivvo/issues",
   "requirements": [],
-  "version": "2.5.1"
+  "version": "2.5.2"
 }


### PR DESCRIPTION
## Summary
Fixes integration compatibility with Home Assistant Core 2025.12+

## Issues Fixed
1. OptionsFlow deprecation causing `AttributeError` on config entry access
2. TypeError when Drivvo API returns null values for volume/price fields

## Changes
- Updated OptionsFlow to use new helper properties (HA Core 2025.12+)
- Added null-safety checks for numeric field aggregations
- Added division-by-zero guards in price calculations

## Tested On
- Home Assistant Core 2025.12.4
- Home Assistant OS

## References
- https://developers.home-assistant.io/blog/2024/11/12/options-flow/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for refuelling and odometer calculations to prevent crashes when processing incomplete or invalid data values.

* **Chores**
  * Version bumped to 2.5.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->