### PR TITLE
Fix volume calculation when API returns null values

### DIFF
--- a/custom_components/drivvo/__init__.py
+++ b/custom_components/drivvo/__init__.py
@@ -264,8 +264,8 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
             for refuelling in api_data_refuellings:
                 refuelling_value_total += refuelling.get("valor_total") or 0
 
-                if refuelling["volume"] != 0:
-                    refuelling_volume_total += refuelling.get("volume") or 0
+                if refuelling.get("volume") and refuelling["volume"] != 0:
+                    refuelling_volume_total += refuelling["volume"]
                 else:
                     volume_calc = 0
                     if refuelling.get("preco") and refuelling.get("preco") != 0:
@@ -344,10 +344,13 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
             refuelling_value = refuelling["valor_total"]
             refuelling_price = refuelling["preco"]
             refuelling_odometer = refuelling["odometro"]
-            if refuelling["volume"] != 0:
+            if refuelling.get("volume") and refuelling["volume"] != 0:
                 refuelling_volume = refuelling["volume"]
             else:
-                refuelling_volume = refuelling["valor_total"] / refuelling["preco"]
+                volume_calc = 0
+                if refuelling.get("preco") and refuelling["preco"] != 0:
+                    volume_calc = refuelling["valor_total"] / refuelling["preco"]
+                refuelling_volume = volume_calc
             refuelling_reason = refuelling["tipo_motivo"]
             refuelling_tank_full = refuelling["tanque_cheio"]
 

--- a/custom_components/drivvo/manifest.json
+++ b/custom_components/drivvo/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-drivvo/issues",
   "requirements": [],
-  "version": "2.5.2"
+  "version": "2.5.3"
 }


### PR DESCRIPTION
## Summary
- Fixed volume calculation to properly handle `null` values returned by the Drivvo API
- Improved error handling to prevent division by zero when price data is missing
- Ensured consistent volume calculation logic across all three locations in the codebase

## Problem
The Drivvo API sometimes returns `null` or `0` for the `volume` field in refuelling data. The previous code had inconsistent null handling:
- Two locations correctly handled both null and 0 values
- One location (line 347) only checked `!= 0`, which caused it to fail when volume was `null`

When `volume` is `null`, the comparison `None != 0` evaluates to `True`, causing the code to attempt using `None` directly instead of calculating volume from `valor_total / preco`.

## Solution
Updated the volume calculation logic in two locations to consistently handle both `null` and `0` values:

1. **Total volume calculation** (lines 267-273): Now uses `.get("volume")` check before comparison
2. **Latest refuelling volume** (lines 347-353): Added proper null checking and division-by-zero protection

The fix implements a consistent pattern:
- Check if volume exists AND is non-zero
- Use API-provided volume if valid
- Calculate fallback: `volume = valor_total / preco` (with safe null/zero checks)
- Default to 0 if price is also missing or zero

## Example
For API response with:
```json
{
  "volume": null,
  "valor_total": 64.07,
  "preco": 1.36
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing or invalid volume data in refuelling records to prevent processing errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->